### PR TITLE
application migration is now verbose during deploy

### DIFF
--- a/kubernetes/kustomize/migrate-application/continuous-deploy/migrate-application.yaml
+++ b/kubernetes/kustomize/migrate-application/continuous-deploy/migrate-application.yaml
@@ -12,7 +12,7 @@ spec:
             containers:
                 -   name: migrate-application
                     image: "{{TAG}}"
-                    command: ["sh", "-c", "cd /var/www/html && ./phing db-migrations-count-with-maintenance build-deploy-part-2-db-dependent"]
+                    command: ["sh", "-c", "cd /var/www/html && ./phing -verbose db-migrations-count-with-maintenance build-deploy-part-2-db-dependent"]
                     securityContext:
                         runAsUser: 33
                     volumeMounts:


### PR DESCRIPTION
When some error occurs while deploying a new version, it might be useful to see a verbose output with lines and errors.