### PR TITLE
added consumer deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,23 +87,26 @@ Environment variables can be set in Gitlab (Settings -> CI/CD -> Variables)
 
 If you want to define your custom variables see [Define custom variables](#define-custom-variables) section
 
-| Name                         | Example                         | Description                                                                                                                 |            Scope |
-|:-----------------------------|---------------------------------|-----------------------------------------------------------------------------------------------------------------------------|-----------------:|
-| DEPLOY_REGISTER_USER         | deploy                          | Credentials for downloading docker images *1)                                                                               |              All |
-| DEPLOY_REGISTER_PASSWORD     | *******                         | Credentials for downloading docker images *1)                                                                               |              All |
-| DISPLAY_FINAL_CONFIGURATION  | _1_ OR _0_                      | Display configurations after kubernetes scripts are prepared                                                                |              All |
-| RUNNING_PRODUCTION           | _1_ OR _0_                      | Enable/disable HTTP auth and mailer whitelist                                                                               | production/devel |
-| FIRST_DEPLOY                 | _1_ OR _0_                      | Set to 1 if you are deploying project instance first time                                                                   | production/devel |
-| DOMAIN_HOSTNAME_*            | example.com                     | Variable contains URL address for accessing website. See  [Add more or less domains](#add-more-or-less-domains)             | production/devel |                                   | All  |
-| ELASTICSEARCH_URL            | username:password@elasticsearch | Elasticsearch login URL                                                                                                     |              All |
-| POSTGRES_DATABASE_IP_ADDRESS | 127.0.0.1                       | Postgres host IP address                                                                                                    | production/devel |
-| POSTGRES_DATABASE_PORT       | 5432                            | Postgres port                                                                                                               |              All |
-| POSTGRES_DATABASE_PASSWORD   | *******                         | Postgres login password                                                                                                     | production/devel |
-| PROJECT_NAME                 | project-prod                    | Name of project (Used for namespace, prefixes and S3 bucket) - must be distinct for production/devel with prod/devel suffix | production/devel |
-| S3_API_HOST                  | https://s3.vshosting.cloud      | S3 API Host                                                                                                                 |              All |
-| S3_API_USERNAME              | s3user                          | S3 API username                                                                                                             |              All |
-| S3_API_PASSWORD              | *******                         | S3 API password                                                                                                             |              All |
-| APP_SECRET                   | *******                         | Used to add more entropy to security related operations                                                                     |              All |
+| Name                         | Example                          | Description                                                                                                                 |            Scope |
+|:-----------------------------|----------------------------------|-----------------------------------------------------------------------------------------------------------------------------|-----------------:|
+| DEPLOY_REGISTER_USER         | deploy                           | Credentials for downloading docker images *1)                                                                               |              All |
+| DEPLOY_REGISTER_PASSWORD     | *******                          | Credentials for downloading docker images *1)                                                                               |              All |
+| DISPLAY_FINAL_CONFIGURATION  | _1_ OR _0_                       | Display configurations after kubernetes scripts are prepared                                                                |              All |
+| RUNNING_PRODUCTION           | _1_ OR _0_                       | Enable/disable HTTP auth and mailer whitelist                                                                               | production/devel |
+| FIRST_DEPLOY                 | _1_ OR _0_                       | Set to 1 if you are deploying project instance first time                                                                   | production/devel |
+| DOMAIN_HOSTNAME_*            | example.com                      | Variable contains URL address for accessing website. See  [Add more or less domains](#add-more-or-less-domains)             | production/devel |
+| ELASTICSEARCH_URL            | username:password@elasticsearch  | Elasticsearch login URL                                                                                                     |              All |
+| POSTGRES_DATABASE_IP_ADDRESS | 127.0.0.1                        | Postgres host IP address                                                                                                    | production/devel |
+| POSTGRES_DATABASE_PORT       | 5432                             | Postgres port                                                                                                               |              All |
+| POSTGRES_DATABASE_PASSWORD   | *******                          | Postgres login password                                                                                                     | production/devel |
+| PROJECT_NAME                 | project-prod                     | Name of project (Used for namespace, prefixes and S3 bucket) - must be distinct for production/devel with prod/devel suffix | production/devel |
+| S3_API_HOST                  | https://s3.vshosting.cloud       | S3 API Host                                                                                                                 |              All |
+| S3_API_USERNAME              | s3user                           | S3 API username                                                                                                             |              All |
+| S3_API_PASSWORD              | *******                          | S3 API password                                                                                                             |              All |
+| APP_SECRET                   | *******                          | Used to add more entropy to security related operations                                                                     |              All |
+| RABBITMQ_DEFAULT_USER        | rabbitadmin                      | Default user used for RabbitMQ and the management service                                                                   |              All |
+| RABBITMQ_DEFAULT_PASS        | *******                          | Password for the default RabbitMQ user                                                                                      |              All |
+| RABBITMQ_IP_WHITELIST        | 123.456.123.422, 423.534.223.234 | IP Addresses (separated by comma) for which is the RabbitMQ Management accessible                                           |              All |
 
 *1) Credentials can be generated in Gitlab (Settings -> Repository -> Deploy Tokens) with `read_registry` scope only 
 

--- a/deploy/functions.sh
+++ b/deploy/functions.sh
@@ -76,3 +76,23 @@ function find_file() {
 function remove_dist() {
     echo ${1%.*}
 }
+
+function create_consumer_manifests() {
+    local DEFAULT_CONSUMERS="$1"
+
+    TEMPLATE_PATH="${CONFIGURATION_TARGET_PATH}/manifest-templates/consumer.template.yaml"
+
+    for CONSUMER in "${DEFAULT_CONSUMERS[@]}"; do
+        IFS=":" read -r NAME TRANSPORT_NAMES REPLICAS_COUNT <<< "$CONSUMER"
+
+        CONSUMER_MANIFEST_PATH="${CONFIGURATION_TARGET_PATH}/deployments/consumer-${NAME}.yaml"
+
+        cp "${TEMPLATE_PATH}" "${CONSUMER_MANIFEST_PATH}"
+
+        sed -i "s|{{NAME}}|${NAME}|g" "${CONSUMER_MANIFEST_PATH}"
+        sed -i "s|{{TRANSPORT_NAMES}}|${TRANSPORT_NAMES}|g" "${CONSUMER_MANIFEST_PATH}"
+        sed -i "s|{{REPLICAS_COUNT}}|${REPLICAS_COUNT}|g" "${CONSUMER_MANIFEST_PATH}"
+
+        sed -i "/resources:/a\    - ../../../deployments/consumer-${NAME}.yaml" "${CONFIGURATION_TARGET_PATH}/kustomize/migrate-application/continuous-deploy/kustomization.yaml"
+    done
+}

--- a/deploy/parts/domain-rabbitmq-management.sh
+++ b/deploy/parts/domain-rabbitmq-management.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+echo -n "Prepare RabbitMQ management domain "
+
+assertVariable "CONFIGURATION_TARGET_PATH"
+assertVariable "DOMAIN_HOSTNAME_1"
+
+DOMAIN="rabbitmq.${DOMAIN_HOSTNAME_1}"
+
+yq write --inplace "${CONFIGURATION_TARGET_PATH}/ingress/ingress-rabbitmq.yaml" spec.rules[0].host ${DOMAIN}
+yq write --inplace "${CONFIGURATION_TARGET_PATH}/ingress/ingress-rabbitmq.yaml" spec.tls[0].hosts[+] ${DOMAIN}
+
+if [ -n "${RABBITMQ_IP_WHITELIST}" ]; then
+    yq write --inplace "${CONFIGURATION_TARGET_PATH}/ingress/ingress-rabbitmq.yaml" metadata.annotations."\"nginx.ingress.kubernetes.io/whitelist-source-range\"" "${RABBITMQ_IP_WHITELIST}"
+fi
+
+echo -e "[${GREEN}OK${NO_COLOR}]"

--- a/deploy/parts/environment-variables.sh
+++ b/deploy/parts/environment-variables.sh
@@ -16,6 +16,14 @@ for key in "${!ENVIRONMENT_VARIABLES[@]}"; do
     then
         echo "Variable '${key}' couldn't be set because it's empty"
     else
+        # Consumer deployments
+        for CONSUMER_FILE in "${CONFIGURATION_TARGET_PATH}/deployments/"consumer-*.yaml; do
+            if [ -f "$CONSUMER_FILE" ]; then
+                yq write --inplace "${CONSUMER_FILE}" "spec.template.spec.containers[0].env[${ITERATOR}].name" ${key}
+                yq write --inplace "${CONSUMER_FILE}" "spec.template.spec.containers[0].env[${ITERATOR}].value" "\"${ENVIRONMENT_VARIABLES[${key}]}\""
+            fi
+        done
+
         # Webserver PHP-FPM deployment
         yq write --inplace "${CONFIGURATION_TARGET_PATH}/deployments/webserver-php-fpm.yaml" "spec.template.spec.containers[0].env[${ITERATOR}].name" ${key}
         yq write --inplace "${CONFIGURATION_TARGET_PATH}/deployments/webserver-php-fpm.yaml" "spec.template.spec.containers[0].env[${ITERATOR}].value" "\"${ENVIRONMENT_VARIABLES[${key}]}\""

--- a/docs/deploy-project.sh
+++ b/docs/deploy-project.sh
@@ -32,6 +32,7 @@ function deploy() {
         ["REDIS_PREFIX"]=${PROJECT_NAME}
         ["MAILER_DSN"]=${MAILER_DSN}
         ["TRUSTED_PROXY"]=10.0.0.0/8
+        ["MESSENGER_TRANSPORT_DSN"]=${MESSENGER_TRANSPORT_DSN}
     )
 
     declare -A STOREFRONT_ENVIRONMENT_VARIABLES=(
@@ -47,10 +48,14 @@ function deploy() {
         STOREFRONT_TAG
         PROJECT_NAME
         BASE_PATH
+        RABBITMQ_DEFAULT_USER
+        RABBITMQ_DEFAULT_PASS
+        RABBITMQ_IP_WHITELIST
     )
 
     source "${DEPLOY_TARGET_PATH}/functions.sh"
     source "${DEPLOY_TARGET_PATH}/parts/domains.sh"
+    source "${DEPLOY_TARGET_PATH}/parts/domain-rabbitmq-management.sh"
     source "${DEPLOY_TARGET_PATH}/parts/environment-variables.sh"
     source "${DEPLOY_TARGET_PATH}/parts/kubernetes-variables.sh"
     source "${DEPLOY_TARGET_PATH}/parts/cron.sh"
@@ -59,8 +64,15 @@ function deploy() {
 }
 
 function merge() {
+    # Specify consumers configuration with the default configuration in the format:
+    # <consumer-name>:<transport-names-separated-by-space>:<number-of-consumers>
+    DEFAULT_CONSUMERS=(
+        "example:example_transport:1"
+    )
+
     source "${BASE_PATH}/vendor/shopsys/deployment/deploy/functions.sh"
     merge_configuration
+    create_consumer_manifests $DEFAULT_CONSUMERS
 }
 
 case "$1" in

--- a/kubernetes/deployments/rabbitmq.yaml
+++ b/kubernetes/deployments/rabbitmq.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: rabbitmq
+spec:
+    replicas: 1
+    selector:
+        matchLabels:
+            app: rabbitmq
+    template:
+        metadata:
+            labels:
+                app: rabbitmq
+        spec:
+            affinity:
+                podAntiAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                        -   weight: 100
+                            podAffinityTerm:
+                                topologyKey: "kubernetes.io/hostname"
+                                labelSelector:
+                                    matchExpressions:
+                                        -   key: app
+                                            operator: In
+                                            values:
+                                                - rabbitmq
+            containers:
+                -   name: rabbitmq
+                    image: rabbitmq:3.12-management-alpine
+                    ports:
+                        -   name: rabbitmq
+                            containerPort: 15672
+                            protocol: TCP
+                    env:
+                        -   name: RABBITMQ_DEFAULT_USER
+                            value: "{{RABBITMQ_DEFAULT_USER}}"
+                        -   name: RABBITMQ_DEFAULT_PASS
+                            value: "{{RABBITMQ_DEFAULT_PASS}}"
+                    resources:
+                        limits:
+                            cpu: "2"
+                        requests:
+                            cpu: "0.3"
+            imagePullSecrets:
+                -   name: dockerregistry

--- a/kubernetes/ingress/ingress-rabbitmq.yaml
+++ b/kubernetes/ingress/ingress-rabbitmq.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+    name: rabbitmq-domain
+    annotations:
+        kubernetes.io/ingress.class: nginx
+        ingress.kubernetes.io/ssl-redirect: "true"
+        cert-manager.io/cluster-issuer: letsencrypt-prod
+        nginx.ingress.kubernetes.io/proxy-body-size: 32m
+spec:
+    tls:
+        -   hosts: ~
+            secretName: tls-rabbitmq-domain
+    rules:
+        -   host: ~
+            http:
+                paths:
+                    -   path: "/"
+                        backend:
+                            serviceName: rabbitmq
+                            servicePort: 15672

--- a/kubernetes/kustomize/migrate-application/continuous-deploy/kustomization.yaml
+++ b/kubernetes/kustomize/migrate-application/continuous-deploy/kustomization.yaml
@@ -3,6 +3,8 @@ resources:
     - ../../../services/redis.yaml
     - ../../../namespace.yaml
     - ../../../configmap/redis-health.yaml
+    - ../../../deployments/rabbitmq.yaml
+    - ../../../services/rabbitmq.yaml
     - ./migrate-application.yaml
 namespace: "{{PROJECT_NAME}}"
 configMapGenerator:

--- a/kubernetes/kustomize/webserver/kustomization.yaml
+++ b/kubernetes/kustomize/webserver/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
     - ../../configmap/nginx.yaml
     - ../../configmap/production-php-fpm.yaml
     - ../../configmap/production-php-opcache.yaml
+    - ../../ingress/ingress-rabbitmq.yaml
 namespace: "{{PROJECT_NAME}}"
 configMapGenerator:
     -   name: domains-urls

--- a/kubernetes/manifest-templates/consumer.template.yaml
+++ b/kubernetes/manifest-templates/consumer.template.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: consumer-{{NAME}}
+    labels:
+        app: consumer-{{NAME}}
+spec:
+    progressDeadlineSeconds: 600
+    replicas: {{REPLICAS_COUNT}}
+    strategy:
+        rollingUpdate:
+            maxSurge: 1
+            maxUnavailable: 0
+        type: RollingUpdate
+    selector:
+        matchLabels:
+            app: consumer-{{NAME}}
+    template:
+        metadata:
+            labels:
+                app: consumer-{{NAME}}
+        spec:
+            volumes:
+                -   name: domains-urls
+                    configMap:
+                        name: domains-urls
+                -   name: fe-api-keys-volume
+                    secret:
+                        secretName: fe-api-keys
+                        defaultMode: 0644
+            terminationGracePeriodSeconds: 3600
+            containers:
+                -   image: "{{TAG}}"
+                    name: consumer-{{NAME}}
+                    securityContext:
+                        runAsUser: 33
+                    imagePullPolicy: Always
+                    workingDir: /var/www/html
+                    command:
+                        - /bin/sh
+                        - -c
+                        - sleep 5 && ./phing warmup && bin/console messenger:consume {{TRANSPORT_NAMES}} --time-limit=600 -vv
+                    lifecycle:
+                        preStop:
+                            exec:
+                                command: ["php", "./bin/console messenger:stop-workers"]
+                    volumeMounts:
+                        -   name: domains-urls
+                            mountPath: /var/www/html/{{DOMAINS_URLS_FILEPATH}}
+                            subPath: "{{DOMAINS_URLS_FILENAME}}"
+                        -   name: fe-api-keys-volume
+                            readOnly: true
+                            mountPath: /var/www/html/config/frontend-api
+            imagePullSecrets:
+                -   name: dockerregistry

--- a/kubernetes/services/rabbitmq.yaml
+++ b/kubernetes/services/rabbitmq.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: rabbitmq
+spec:
+    selector:
+        app: rabbitmq
+    ports:
+        -   name: rabbitmq
+            port: 5672
+            targetPort: 5672
+        -   name: rabbitmq-management
+            port: 15672
+            targetPort: 15672


### PR DESCRIPTION
This PR adds a infrastructure to deploy rabbitmq message broker along with the easy consumer deployment.

consumers may be specified in the project's deploy_project.sh file as  `<consumer-name>:<transport-names-separated-by-space>:<number-of-consumers>`, for example
```
DEFAULT_CONSUMERS=(
    "example:example_transport:1"
)
```

Also, the rabbitmq management interface is exposed on the URL `rabbitmq.<first_domain_url>`.
Access to this management interface may be limited to certain IP addresses with ENV variable `RABBITMQ_IP_WHITELIST `