### PR TITLE
nginx.yaml - fix legacy images redirect

### DIFF
--- a/kubernetes/configmap/nginx.yaml
+++ b/kubernetes/configmap/nginx.yaml
@@ -123,12 +123,12 @@ data:
                         try_files $uri @app;
                     }
 
-                    location ~ ^\/content\/images\/(?<entity_name>\w+)(?<image_type>\/\w+)?\/(?<image_size>(default|original|galleryThumbnail|modal|list|thumbnail|thumbnailSmall|thumbnailExtraSmall|thumbnailMedium|header|footer|productList|productListSecondRow|cartPreview|productListMiddle|productListMiddleRetina|listAside|listGrid|searchThumbnail|listBig)\/)(?<add_image_id>\d+--)?(?<image_name>[\w\-]+_(?<image_id>\d+))\.(?<image_extension>jpg|jpeg|png|gif) {
+                    location ~ ^\/content\/images\/(?<entity_name>\w+)(?<image_type>\/\w+)?\/(?<image_size>(default|original|galleryThumbnail|modal|list|thumbnail|thumbnailSmall|thumbnailExtraSmall|thumbnailMedium|header|footer|productList|productListSecondRow|cartPreview|productListMiddle|productListMiddleRetina|listAside|listGrid|searchThumbnail|listBig)\/)(?<add_image_id>\d+--)?(?<image_name>([\w\-]+_)?(?<image_id>\d+))\.(?<image_extension>jpg|jpeg|png|gif) {
                          expires 1w;
                          return 301 $scheme://$http_host/content/images/$entity_name$image_type/$image_name.$image_extension$is_args$args;
                     }
 
-                    location ~ ^\/content\/images\/(?<entity_name>\w+)(?<image_type>\/\w+)?\/(?<image_name>[\w\-]+_(?<image_id>\d+))\.(?<image_extension>jpg|jpeg|png|gif) {
+                    location ~ ^\/content\/images\/(?<entity_name>\w+)(?<image_type>\/\w+)?\/(?<image_name>([\w\-]+_)?(?<image_id>\d+))\.(?<image_extension>jpg|jpeg|png|gif) {
                         expires 1w;
 
                         error_page 418 = @imageResizer;


### PR DESCRIPTION
The legacy images might be in a format without the image name (e.g. content/images/sliderItem/mobile/default/103.jpg)