### PR TITLE
redis cache is now cleared only once instead of at every container start

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,16 @@
+# Upgrade notes
+
+## How to Upgrade
+
+1. In `composer.json` upgrade `shopsys/deployment` to new version:
+    ```diff
+   - "shopsys/deployment": "~1.9.0",
+   + "shopsys/deployment": "~1.12.0",
+    ```
+2. Run `composer update shopsys/deployment`
+3. Check files in mentioned pull requests and if you have any of them extended in your project, apply changes manually
+
+## Upgrade from v2.0.1 to v2.1.0
+
+- clear Redis cache only once instead of at every container start ([#7](https://github.com/shopsys/deployment/pull/7/files))
+    - phing target `clean-redis-storefront` is available from shopsys/framework v14.0.0

--- a/kubernetes/deployments/webserver-php-fpm.yaml
+++ b/kubernetes/deployments/webserver-php-fpm.yaml
@@ -88,9 +88,6 @@ spec:
                     imagePullPolicy: Always
                     workingDir: /var/www/html
                     lifecycle:
-                        postStart:
-                            exec:
-                                command: ["/var/www/html/phing", "-S", "maintenance-off", "clean-redis-old"]
                         preStop:
                             exec:
                                 command:


### PR DESCRIPTION
Redis cache is now cleared only once during deployment instead of after every container starts. 
Also, the translation and query cache is cleared.