### PR TITLE
Fix redirect chain

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -13,6 +13,7 @@
 ## Upgrade from v2.1.3 to v3.0.0
 
 - refactor working with whitelisted IP addresses ([#11](https://github.com/shopsys/deployment/pull/11))
+- fix redirect chain ([#12](https://github.com/shopsys/deployment/pull/12))
 
 ## Upgrade from v2.1.2 to v2.1.3
 


### PR DESCRIPTION
Ingress has bug that runs redirect chain in wrong order. To prevent it we implemented workaround solution for that.

### Example

**Previous** : http://domain.com -> http://www.domain.com -> https://www.domain.com
**Now** : http://domain.com -> https://domain.com -> https://www.domain.com

Ingress issue: https://github.com/kubernetes/ingress-nginx/issues/6340

