### PR TITLE
Update FPM workers and set terminate timeout

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -13,6 +13,7 @@
 ## Upgrade from v3.2.2 to v3.2.3
 
 - implemented script to send slack notification about deployment process ([#23](https://github.com/shopsys/deployment/pull/23))
+- updated fpm workers and set terminate timeout ([#24](https://github.com/shopsys/deployment/pull/24))
 
 ## Upgrade from v3.2.1 to v3.2.2
 

--- a/kubernetes/configmap/production-php-fpm.yaml
+++ b/kubernetes/configmap/production-php-fpm.yaml
@@ -15,8 +15,13 @@ data:
 
         listen = 127.0.0.1:9000
 
-        pm = static
-        pm.max_children = 8
-        pm.max_requests = 1000
+        pm = dynamic
+        pm.max_children = 20
+        pm.start_servers = 5
+        pm.min_spare_servers = 5
+        pm.max_spare_servers = 10
+        pm.max_requests = 400
+
+        request_terminate_timeout = 60s
 
         access.log = /dev/null


### PR DESCRIPTION
Just a little bit optimization of FPM workers by increasing them. I added terminate timeout to prevent endless running