### PR TITLE
blocked dynamic content on CDN now returns 403 code

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -10,6 +10,10 @@
 2. Run `composer update shopsys/deployment`
 3. Check files in mentioned pull requests and if you have any of them extended in your project, apply changes manually
 
+## Upgrade from v3.2.5 to v3.2.6
+
+- blocked dynamic content on CDN now returns 403 code ([#27](https://github.com/shopsys/deployment/pull/27))
+
 ## Upgrade from v3.2.4 to v3.2.5
 
 - returns only static content from vshosting CDN ([#25](https://github.com/shopsys/deployment/pull/25))

--- a/kubernetes/configmap/nginx.yaml
+++ b/kubernetes/configmap/nginx.yaml
@@ -194,10 +194,10 @@ data:
             # disallow access to dynamic content from CDN
             location ~ / {
                 if ($http_cdn_vshosting_real_ip != '') {
-                    return 410;
+                    return 403;
                 }
                 if ($http_cdn_vshosting_real_ip_img != '') {
-                    return 410;
+                    return 403;
                 }
 
                 try_files @storefront @storefront;


### PR DESCRIPTION
When blocking requests for dynamic content that should not be served via CDN, the appropriate HTTP status code to return is 403 Forbidden.
This status code indicates that the server understands the request but refuses to authorize it. 
It’s suitable in this context because the client is making a valid request, but the server is intentionally refusing to fulfill it.