### PR TITLE
Finding running container for after deploy tasks is fixed

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -10,6 +10,10 @@
 2. Run `composer update shopsys/deployment`
 3. Check files in mentioned pull requests and if you have any of them extended in your project, apply changes manually
 
+## Upgrade from v3.3.0 to v3.3.1
+
+- Finding running container for after deploy tasks is fixed ([#33](https://github.com/shopsys/deployment/pull/31))
+
 ## Upgrade from v3.2.9 to v3.3.0
 
 - Cron can run under Alpine Linux ([#31](https://github.com/shopsys/deployment/pull/31))

--- a/deploy/parts/deploy.sh
+++ b/deploy/parts/deploy.sh
@@ -184,7 +184,7 @@ if [ ${ENABLE_AUTOSCALING} = true ]; then
     runCommand "ERROR" "kubectl apply -f ${CONFIGURATION_TARGET_PATH}/horizontalStorefrontAutoscaler.yaml"
 fi
 
-RUNNING_WEBSERVER_PHP_FPM_POD=$(kubectl get pods --namespace=${PROJECT_NAME} --field-selector=status.phase=Running -l app=webserver-php-fpm -o=jsonpath='{.items[0].metadata.name}')
+RUNNING_WEBSERVER_PHP_FPM_POD=$(kubectl get pods --namespace=${PROJECT_NAME} --field-selector=status.phase=Running -l app=webserver-php-fpm -o=jsonpath='{.items[?(@.status.containerStatuses[0].state.running)].metadata.name}')
 
 echo -n "Disable maintenance page "
 runCommand "ERROR" "kubectl exec ${RUNNING_WEBSERVER_PHP_FPM_POD} --namespace=${PROJECT_NAME} -- ./phing maintenance-off"


### PR DESCRIPTION
Sometimes happens that tasks after deploy are not executed because there was no check that it is executed on running container. This PR fixes it

closes #32