### PR TITLE
Fix problems with deployment

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -10,6 +10,10 @@
 2. Run `composer update shopsys/deployment`
 3. Check files in mentioned pull requests and if you have any of them extended in your project, apply changes manually
 
+## Upgrade from v3.3.2 to v3.3.3
+
+- Fix problems with deployment ([#35](https://github.com/shopsys/deployment/pull/35))
+
 ## Upgrade from v3.3.1 to v3.3.2
 
 - Redis was upgraded to version 7.4-alpine ([#34](https://github.com/shopsys/deployment/pull/34))

--- a/kubernetes/deployments/storefront.yaml
+++ b/kubernetes/deployments/storefront.yaml
@@ -36,7 +36,7 @@ spec:
                             exec:
                                 command:
                                     - sleep
-                                    - '5'
+                                    - '10'
                     resources:
                         limits:
                             cpu: "2"
@@ -56,5 +56,6 @@ spec:
                         initialDelaySeconds: 5
                         periodSeconds: 5
                         timeoutSeconds: 5
+            terminationGracePeriodSeconds: 60
             imagePullSecrets:
                 -   name: dockerregistry

--- a/kubernetes/deployments/webserver-php-fpm.yaml
+++ b/kubernetes/deployments/webserver-php-fpm.yaml
@@ -90,8 +90,9 @@ spec:
                         preStop:
                             exec:
                                 command:
-                                    - sleep
-                                    - '5'
+                                    - sh
+                                    - '-c'
+                                    - sleep 10 && kill -SIGQUIT 1
                     volumeMounts:
                         -   name: source-codes
                             mountPath: /var/www/html
@@ -157,5 +158,6 @@ spec:
                         requests:
                             cpu: "0.5"
                             memory: 500Mi
+            terminationGracePeriodSeconds: 120
             imagePullSecrets:
                 -   name: dockerregistry

--- a/kubernetes/kustomize/migrate-application/first-deploy-with-demo-data/migrate-application.yaml
+++ b/kubernetes/kustomize/migrate-application/first-deploy-with-demo-data/migrate-application.yaml
@@ -15,7 +15,7 @@ spec:
                     command:
                         - sh
                         - -c
-                        - cd /var/www/html &&
+                        - cd /var/www/html && sleep 30 &&
                             ./phing 
                             cluster-first-deploy 
                             db-fixtures-demo

--- a/kubernetes/kustomize/migrate-application/first-deploy/migrate-application.yaml
+++ b/kubernetes/kustomize/migrate-application/first-deploy/migrate-application.yaml
@@ -12,7 +12,7 @@ spec:
             containers:
                 -   name: migrate-application
                     image: "{{TAG}}"
-                    command: ["sh", "-c", "cd /var/www/html && ./phing cluster-first-deploy"]
+                    command: ["sh", "-c", "cd /var/www/html && sleep 30 && ./phing cluster-first-deploy"]
                     volumeMounts:
                         -   name: domains-urls
                             mountPath: /var/www/html/{{DOMAINS_URLS_FILEPATH}}


### PR DESCRIPTION
This PR fixes two issues:

1. When you deploy a new app, sometimes `migrate-application` runs before Redis is ready -> added 30 seconds before the migration starts. This is only for newly deployed apps.
2. Sometimes between deployments some users could get errors because we didn't respect graceful shutdowns of our app. This is also fixed